### PR TITLE
Fix "File does not exist at path" error

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -35,7 +35,7 @@ class ChunkUpload {
     async getBase64Chunks() {
         let i = 0;
         await RNFetchBlob.fs.readStream(
-            'file://' + (this.data.path).replace('file://', ''),
+            this.data.path,
             'base64',
             this.data.size
         )


### PR DESCRIPTION
On iOS rn-fetch-blob expects the file path to not start with `file://`. Currently it throws a "File does not exist at path file://..." error.

This change removes adding `file://` prefix and just uses the path passed in the constructor.